### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.aux
+*.idx
+*.log
+*.out
+*.pdf
+*.toc
+


### PR DESCRIPTION
Keeps 'git status' clean & makes it less likely to accidentally commit files we don't want committed (e.g. detector.toc)
