### PR TITLE
Change document type from scrartcl to article

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -1,4 +1,4 @@
-\documentclass[11pts,english,letterpaper]{scrartcl}
+\documentclass[11pts,english,letterpaper]{article}
 %\usepackage{SIunits}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}


### PR DESCRIPTION
 I was getting the error with my tex setup (tex live 2016 through mactex):
```
! Class scrartcl Error: undefined old font command `\tt'.
```
Even if this works for you now, it will almost certainly stop working with future distributions.
There are a couple of ways of fixing this:
1. Change the document type from scrartcl to article
1. Define `\tt` as something that works

This pull request uses option 1.